### PR TITLE
Prevent Empty Space in Header

### DIFF
--- a/style.css
+++ b/style.css
@@ -1544,6 +1544,11 @@ object {
 		max-width: none;
 	}
 	
+	.home #masthead {
+		margin-bottom: 50px;
+		max-height: 150px;
+	}
+	
 	.menu { 
 		padding-top: 0;
 	}		
@@ -1573,7 +1578,9 @@ object {
 	}
 	
 	.wp-custom-logo .jetpack-social-navigation{
-		margin: -60px 0 6px 0;
+		background-color: #fff;
+		margin: -60px 0 10px 0;
+		max-height: 55px;
 	}
 	
 	.jetpack-social-navigation ul li {

--- a/style.css
+++ b/style.css
@@ -801,7 +801,7 @@ a:hover {
      padding: 80px 90px;
      border: 2px solid white;
      border-bottom: 0;
-     margin-top: 7%;
+     margin-top: 125px;
      max-width: 100%;
      background: rgba(255,255,255,0.7);
      font-weight: 500;
@@ -1563,11 +1563,7 @@ object {
 		position: relative;
 		width: auto;
 	}
-	
-	.site-title {
-		margin-top: 20%;
-	}
-	
+			
 	.site-branding .site-description {
 		display: none;
 	}


### PR DESCRIPTION
When a custom logo is set, but no social menu has been added, and the site is viewed on mobile so that the tagline is no longer in the header,  all works as expected. But seeing it now, the masthead displays a bit too much white space for my liking. Let's try to minimise that as much as possible. 